### PR TITLE
Fix Scout APM integration

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,8 +10,7 @@ external_stylesheets = [ dbc.themes.BOOTSTRAP, 'https://codepen.io/almostburtmac
 
 
 app = dash.Dash(__name__, external_stylesheets=external_stylesheets)
-ScoutApm(app)
-server = app.server
 app.config.suppress_callback_exceptions = True
-app.config["SCOUT_NAME"] = "Baseball App"
-
+flask = app.server
+ScoutApm(flask)
+flask.config["SCOUT_NAME"] = "Baseball App"


### PR DESCRIPTION
Dash exposes a `Dash` class for your app, which [wraps a Flask server](https://github.com/plotly/dash/blob/3c5900f963ada2a49bfe5b67b65973cb223bbab9/dash/dash.py#L245). To use the Scout APM Flask integration, we need to connect to the underlying `Flask` object rather than the `Dash` app.

I haven't tested this but after reading the Dash source code I'm pretty sure it should work.